### PR TITLE
Upgrade action to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ inputs:
     description: 'Makes no real changes'
     default: 'false'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Bumps the action to using node16, so we get rid of the deprecation warnings.